### PR TITLE
プレイ時間を表示

### DIFF
--- a/src/renderer/hooks/usePlayTime.tsx
+++ b/src/renderer/hooks/usePlayTime.tsx
@@ -1,0 +1,31 @@
+import { useState, useEffect } from 'react';
+
+export type TUsePlayTime = {
+  timeCount: number;
+  playTime: string;
+};
+
+export const usePlayTime = (): TUsePlayTime => {
+  const [timeCount, setCount] = useState(0);
+  const [playTime, setPlayTime] = useState('0:00');
+
+  const countup = () => {
+    const currentCount = timeCount + 1;
+    setCount(currentCount);
+
+    const seconds =
+      (currentCount < 10 ? '0' : '') + (currentCount % 60).toString();
+    const minutes = Math.floor(currentCount / 60).toString();
+    setPlayTime(`${minutes}:${seconds}`);
+  };
+
+  useEffect(() => {
+    const timerId = setInterval(countup, 1000);
+    return () => clearInterval(timerId);
+  }, [countup]);
+
+  return {
+    timeCount,
+    playTime,
+  };
+};

--- a/src/renderer/view/pages/Typing/index.tsx
+++ b/src/renderer/view/pages/Typing/index.tsx
@@ -4,12 +4,14 @@ import { TextToType } from '../../components/TextToType';
 import { typingContainer } from './typingContainer';
 import { TPageList } from '../../../../common/types';
 import { PAGE_LIST } from '../../../../common/const';
+import { usePlayTime } from '../../../hooks/usePlayTime';
 
 type TTypingPage = {
   setCurrentPage: (pageName: TPageList) => void;
 };
 export const TypingPage = ({ setCurrentPage }: TTypingPage) => {
   const { word, clearDisplayWord, isAllCleared } = typingContainer();
+  const { timeCount, playTime } = usePlayTime();
 
   useEffect(() => {
     if (isAllCleared) setCurrentPage(PAGE_LIST.SCORE);
@@ -17,7 +19,12 @@ export const TypingPage = ({ setCurrentPage }: TTypingPage) => {
 
   return (
     <div>
-      {word && <TextToType text={word} onClearDisplayWord={clearDisplayWord} />}
+      <div>
+        {word && (
+          <TextToType text={word} onClearDisplayWord={clearDisplayWord} />
+        )}
+      </div>
+      <div>{playTime}</div>
     </div>
   );
 };

--- a/src/renderer/view/pages/Typing/typingContainer.tsx
+++ b/src/renderer/view/pages/Typing/typingContainer.tsx
@@ -7,7 +7,7 @@ export type TTypingContainer = {
   isAllCleared: boolean;
 };
 
-export const typingContainer = () => {
+export const typingContainer = (): TTypingContainer => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [word, setWord] = useState('');
   const [isAllCleared, setiIsAllCleared] = useState(false);


### PR DESCRIPTION
- usePlayTimeを追加
- TypingページでusePlayTimeを実行してプレイ時間を取得・表示
- 今後storeを作成したらプレイカウント（number）、正答率、タイプ文言を管理する